### PR TITLE
Move broccoli-funnel & broccoli-merge-trees to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,14 +18,14 @@
     "test": "ember try:each"
   },
   "dependencies": {
+    "broccoli-funnel": "^1.2.0",
+    "broccoli-merge-trees": "^2.0.0",
     "ember-cli-babel": "^6.3.0",
     "ember-cli-htmlbars": "^2.0.3"
   },
   "devDependencies": {
     "bricks.js": "^1.8.0",
     "broccoli-asset-rev": "^2.4.5",
-    "broccoli-funnel": "^1.2.0",
-    "broccoli-merge-trees": "^2.0.0",
     "ember-ajax": "^3.0.0",
     "ember-cli": "~2.14.1",
     "ember-cli-dependency-checker": "^1.3.0",


### PR DESCRIPTION
`broccoli-funnel` and `broccoli-merge-trees` seem to be required dependencies for proper install to work: https://github.com/Rastopyr/ember-cli-bricks/issues/1