### PR TITLE
expose "repack" API

### DIFF
--- a/addon/templates/components/bricks-grid.hbs
+++ b/addon/templates/components/bricks-grid.hbs
@@ -2,5 +2,6 @@
   {{yield (hash
     item=(component 'bricks-grid/item' repack=(action repack))
     image=(component 'bricks-grid/image' repack=(action repack))
+    repack=(action repack)
   )}}
 </div>


### PR DESCRIPTION
I needed to handle `video` tag `poster` attribute load event.

So instead of creating a `video` component, why don't we expose `repack` action for everyone to freakout anyhow they want? 